### PR TITLE
Correct spelling of perl from purl in documentation

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -60,8 +60,8 @@ Default value: `'https://cpanmin.us'`
 Data type: `Boolean`
 
 Wether this module should manage the following dependencies
-- purl
-- purl-core (rhel7)
+- perl
+- perl-core (rhel7)
 - make
 - gcc
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,8 +6,8 @@
 #
 # @param manage_dependencies
 #   Wether this module should manage the following dependencies
-#   - purl
-#   - purl-core (rhel7)
+#   - perl
+#   - perl-core (rhel7)
 #   - make
 #   - gcc
 #


### PR DESCRIPTION
#### Pull Request (PR) description
The documentation for the cpanm class incorrectly spells "perl" as "purl," this corrects that and corrects the REFERENCE.md as well

#### This Pull Request (PR) fixes the following issues
None, though I can open an issue for this if needed
